### PR TITLE
Update form.py

### DIFF
--- a/discord/ext/forms/form.py
+++ b/discord/ext/forms/form.py
@@ -260,7 +260,8 @@ class Form:
                 if self.editanddelete:
                     await msg.delete()
                 key = question
-                if 'type' in self._questions[self._questions.index(question)].keys():
+                
+                if self._questions[self._questions.index(question)].get('type', None):
                     qinfo = self._questions[self._questions.index(question)]
                     
                     for func in qinfo['type']:


### PR DESCRIPTION
'type' key will always be present in keys, with either an empty list or list of types. 
Due to this, if an empty list is present then a NameError would be raised due to name `correct` being undefined